### PR TITLE
Changed to use uuid chaning instead of timing. This is better for future Use on EPG Summary.

### DIFF
--- a/src/lib/apiWrapper.ts
+++ b/src/lib/apiWrapper.ts
@@ -1,0 +1,5 @@
+type fetchFun = (input: RequestInfo | URL, init?: RequestInit | undefined) => Promise<Response>;
+
+export async function apiGetEvent(fetch: fetchFun, eventId: string) {
+	return fetch(`/api/v1/epg/events/${eventId}`);
+}

--- a/src/lib/components/epg/EPGEventSummary.svelte
+++ b/src/lib/components/epg/EPGEventSummary.svelte
@@ -8,8 +8,6 @@
 	const piconUrl = 'https://codingfragments.github.io/tv-epg-picon.github.io/picons/';
 
 	export let epgEvent: ITVHEpgEvent;
-	export let epgPrev: ITVHEpgEvent | undefined = undefined;
-	export let epgNext: ITVHEpgEvent | undefined = undefined;
 
 	export let showChannelNumber = false;
 	export let showFullDate = false;
@@ -97,22 +95,20 @@
 			<!-- Lineup next and previous -->
 			{#if expanded}
 				<div class="grid grid-cols-2 mt-1 ">
-					{#if epgPrev}
+					{#if epgEvent.prevEventUuid}
 						<!-- svelte-ignore a11y-click-events-have-key-events -->
 						<div
 							class="btn btn-outline btn-sm col-start-1 mx-0.5"
-							on:click|stopPropagation={() =>
-								dispatch('timeSelected', new Date(epgPrev?.startDate ?? ''))}
+							on:click|stopPropagation={() => dispatch('epgSelected', epgEvent.prevEventUuid)}
 						>
 							<Icon icon="navigate_before" size="sm" />
 						</div>
 					{/if}
-					{#if epgNext}
+					{#if epgEvent.nextEventUuid}
 						<!-- svelte-ignore a11y-click-events-have-key-events -->
 						<div
 							class="btn btn-outline btn-sm col-start-2 mx-0.5"
-							on:click|stopPropagation={() =>
-								dispatch('timeSelected', new Date(epgNext?.startDate ?? ''))}
+							on:click|stopPropagation={() => dispatch('epgSelected', epgEvent.nextEventUuid)}
 						>
 							<Icon icon="navigate_next" size="sm" />
 						</div>

--- a/src/routes/app/epg/event/[eventId]/+page.ts
+++ b/src/routes/app/epg/event/[eventId]/+page.ts
@@ -1,9 +1,10 @@
+import { apiGetEvent } from '$lib/apiWrapper';
 import type { ITVHEpgEvent } from '$lib/types/epg-interfaces';
 import { error } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ params, fetch }) => {
-	const result = await fetch(`/api/v1/epg/events/${params.eventId}`);
+	const result = await apiGetEvent(fetch, params.eventId);
 	if (result.status >= 300) {
 		throw error(result.status, result.statusText);
 	}

--- a/src/stories/components/EPGSummary.stories.svelte
+++ b/src/stories/components/EPGSummary.stories.svelte
@@ -16,9 +16,7 @@
 		searchDate: { control: 'date' },
 
 		epgEvent: { control: 'object' },
-		epgNext: { control: 'object' },
-		epgPrev: { control: 'object' },
-		onTimeSelected: { action: 'onTimeSelected' }
+		onEpgSelected: { action: 'onEpgSelected' }
 	}}
 />
 
@@ -30,7 +28,7 @@
 					<EpgEventSummary
 						{...args}
 						searchDate={new Date(args.searchDate)}
-						on:timeSelected={args.onTimeSelected}
+						on:epgSelected={args.onEpgSelected}
 					/>
 				</div>
 			</div>
@@ -53,9 +51,7 @@
 		showChannelNumber: false,
 		showFullDate: false,
 		searchDate: new Date('2022-12-11T20:00'),
-		epgEvent: epgEvent_Single,
-		epgNext: undefined,
-		epgPrev: undefined
+		epgEvent: epgEvent_Single
 	}}
 />
 
@@ -63,8 +59,7 @@
 	name="Pre/Next"
 	args={{
 		epgEvent: epgEvent_Single,
-		epgNext: epgEvent_Single_post,
-		epgPrev: epgEvent_Single_pre,
+
 		expanded: true
 	}}
 />
@@ -72,7 +67,7 @@
 	name="Next"
 	args={{
 		epgEvent: epgEvent_Single,
-		epgNext: epgEvent_Single_post,
+
 		expanded: true,
 		interactive: false
 	}}

--- a/src/stories/components/Events.ts
+++ b/src/stories/components/Events.ts
@@ -41,7 +41,8 @@ export const epgEvent_Single_pre: ITVHEpgEvent = {
 		bouquet: ''
 	},
 	uuid: '74975293',
-	nextEventUuid: '74975294'
+	nextEventUuid: '74975294',
+	prevEventUuid: '74847811'
 };
 export const epgEvent_Single_post: ITVHEpgEvent = {
 	eventId: 74975295,
@@ -130,5 +131,6 @@ export const epgEvent_Single: ITVHEpgEvent = {
 		bouquet: ''
 	},
 	uuid: '74975294',
-	nextEventUuid: '74975295'
+	nextEventUuid: '74975295',
+	prevEventUuid: 'jksjkdj'
 };


### PR DESCRIPTION
Added a better handling on next/prev chaining to EPGSummary. Also used an api-wrapper to make sure we declare local API Fetch at one place with eventuall allows renaming in a single spot.


